### PR TITLE
CI: Drop Node.js 12.x, and windows+Node.js 17.x

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -15,10 +15,8 @@ jobs:
         os:
           - ubuntu-latest
         # 16.12.0 has broken ESM support
-        node-version: ['12.x', '14.x', '16.11.x', '17.x']
+        node-version: ['14.x', '16.11.x', '17.x']
         include:
-          - os: windows-latest
-            node-version: '17.x'
           - os: macos-latest
             node-version: '17.x'
 


### PR DESCRIPTION
# Description

"Since this is a browser library we don't need to test it extensively on many OS/Node versions."

Fixes #39.

# Motivation & context

This makes Windows build failures go away, by not testing on Windows.

One goal here is to get to a consistent green build.

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

# Checklist:


- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
